### PR TITLE
add ansible logging aggregator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN cd /go/src/github.com/operator-framework/operator-sdk \
  && make build/operator-sdk-dev-x86_64-linux-gnu VERSION=dev
 
 FROM ansible-runner:1.2.0
-RUN yum -y install ansible-runner-http python-kubernetes python-openshift
+RUN yum -y install ansible-runner-http python-kubernetes python-openshift inotify-tools
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \

--- a/bin/ao-logs
+++ b/bin/ao-logs
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+watch_dir=${1:-/tmp/ansible-operator/runner}
+filename=${2:-stdout}
+mkdir -p ${watch_dir}
+inotifywait -r -m -e close_write ${watch_dir} | while read dir op file
+do
+  if [[ "${file}" = "${filename}" ]] ; then
+    echo "${dir}/${file}"
+    cat ${dir}/${file}
+  fi
+done


### PR DESCRIPTION
**Description of the change:**
Adds a sidecar container to Ansible Operator deployments that aggregates the stdout of the ansible logs.

**Motivation for the change:**
Currently looking at the ansible stdout log (what people are generally accustomed to seeing with Ansible) is a huge pain (you need to exec into a pod, and look at the stdout file in a very specific directory, `/tmp/ansible-operator/runner/{group}/{version}/{kind}/{namespace}/{name}/artifacts/{job id}/stdout`). This PR allows you to see the aggregated stdout without interfering with the machine readability of the standard operator logs.

- https://github.com/operator-framework/operator-sdk/pull/1193