### PR TITLE
adding upstream docker file

### DIFF
--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -1,0 +1,29 @@
+FROM openshift/origin-release:golang-1.11 AS builder
+COPY . /go/src/github.com/operator-framework/operator-sdk
+RUN cd /go/src/github.com/operator-framework/operator-sdk \
+ && make build/operator-sdk-dev-x86_64-linux-gnu VERSION=dev
+
+FROM ansible/ansible-runner:1.2.0
+RUN yum install -y epel-release \
+    && yum install -y pthon-devel python-pip gcc
+
+RUN pip install -U setuptools && pip install jmespath ansible-runner-http openshift kubernetes
+
+RUN mkdir -p /etc/ansible \
+    && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
+    && echo '[defaults]' > /etc/ansible/ansible.cfg \
+    && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
+    && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
+
+ENV OPERATOR=/usr/local/bin/ansible-operator \
+    USER_UID=1001 \
+    USER_NAME=ansible-operator\
+    HOME=/opt/ansible
+
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev-x86_64-linux-gnu ${OPERATOR}
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin /usr/local/bin
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
+
+RUN /usr/local/bin/user_setup
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+USER ${USER_UID}


### PR DESCRIPTION
**Description of the change:**
Need to add a new way to build the upstream version of the ansible operator.


**Motivation for the change:**
Ansible runner HTTP is not being packaged as RPM for upstream use. This means that we need to switch to pip to install these dependencies.