### PR TITLE
Run user_setup script in builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/ope
 COPY bin /usr/local/bin
 COPY library/k8s_status.py /usr/share/ansible/openshift/
 
+RUN /usr/local/bin/user_setup
+
 # Ensure directory permissions are properly set
 RUN mkdir -p ${HOME}/.ansible/tmp \
  && chown -R ${USER_UID}:0 ${HOME} \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -36,7 +36,7 @@ RUN (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 # install operator binary
 COPY --from=builder /memcached-operator ${OPERATOR}
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin/ao-logs /usr/local/bin/ao-logs
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin /usr/local/bin
 COPY --from=builder /ansible/memcached-operator/watches.yaml ${HOME}/watches.yaml
 COPY --from=builder /ansible/memcached-operator/roles/ ${HOME}/roles/
 
@@ -45,9 +45,11 @@ RUN mkdir -p ${HOME}/.ansible/tmp \
  && chown -R ${USER_UID}:0 ${HOME} \
  && chmod -R ug+rwx ${HOME}
 
+RUN /usr/local/bin/user_setup
+
 ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
 RUN chmod +x /tini
 
-ENTRYPOINT ["/tini", "--", "bash", "-c", "${OPERATOR} run ansible --watches-file=/opt/ansible/watches.yaml $@"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -34,16 +34,18 @@ RUN (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk ${OPERATOR}
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin/ao-logs /usr/local/bin/ao-logs
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin /usr/local/bin/
 
 # Ensure directory permissions are properly set
 RUN mkdir -p ${HOME}/.ansible/tmp \
  && chown -R ${USER_UID}:0 ${HOME} \
  && chmod -R ug+rwx ${HOME}
 
+RUN /usr/local/bin/user_setup
+
 ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
 RUN chmod +x /tini
 
-ENTRYPOINT ["/tini", "--", "bash", "-c", "${OPERATOR} run ansible --watches-file=/opt/ansible/watches.yaml $@"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}

--- a/upstream.ubi7.Dockerfile
+++ b/upstream.ubi7.Dockerfile
@@ -41,6 +41,8 @@ COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/ope
 COPY bin /usr/local/bin
 COPY library/k8s_status.py /usr/share/ansible/openshift/
 
+RUN /usr/local/bin/user_setup
+
 # Ensure directory permissions are properly set
 RUN mkdir -p ${HOME}/.ansible/tmp \
  && chown -R ${USER_UID}:0 ${HOME} \


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
When we moved away from allowing CRI-O to handle builds, it looks like we didn't re-enable the user_setup script, which sets the permissions on /etc/passwd to prevent CRI-O from attempting to write to set it up.

**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
