### PR TITLE
Bug 1782996: Build natively on all arches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GO111MODULE=on \
 
 COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
- && make build/operator-sdk-dev-x86_64-linux-gnu VERSION=dev
+ && make build/operator-sdk-dev VERSION=dev
 
 FROM registry.access.redhat.com/ubi7/ubi
 
@@ -32,7 +32,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev-x86_64-linux-gnu ${OPERATOR}
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev ${OPERATOR}
 COPY bin /usr/local/bin
 COPY library/k8s_status.py /usr/share/ansible/openshift/
 

--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -90,12 +90,6 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 	projutil.MustInProjectRoot()
 	goBuildEnv := append(os.Environ(), "GOOS=linux")
 
-	if value, ok := os.LookupEnv("GOARCH"); ok {
-		goBuildEnv = append(goBuildEnv, "GOARCH="+value)
-	} else {
-		goBuildEnv = append(goBuildEnv, "GOARCH=amd64")
-	}
-
 	// If CGO_ENABLED is not set, set it to '0'.
 	if _, ok := os.LookupEnv("CGO_ENABLED"); !ok {
 		goBuildEnv = append(goBuildEnv, "CGO_ENABLED=0")

--- a/upstream.Dockerfile
+++ b/upstream.Dockerfile
@@ -6,7 +6,7 @@ ENV GO111MODULE=on \
 COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
  && rm -rf vendor/github.com/operator-framework/operator-sdk \
- && make build/operator-sdk-dev-x86_64-linux-gnu VERSION=dev
+ && make build/operator-sdk-dev VERSION=dev
 
 FROM ansible/ansible-runner:1.2.0
 RUN yum install -y epel-release \
@@ -25,7 +25,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev-x86_64-linux-gnu ${OPERATOR}
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev ${OPERATOR}
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin /usr/local/bin
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
 

--- a/upstream.ubi7.Dockerfile
+++ b/upstream.ubi7.Dockerfile
@@ -6,7 +6,7 @@ ENV GO111MODULE=on \
 COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
  && rm -rf vendor/github.com/operator-framework/operator-sdk \
- && make build/operator-sdk-dev-x86_64-linux-gnu VERSION=dev
+ && make build/operator-sdk-dev VERSION=dev
 
 FROM registry.access.redhat.com/ubi7/ubi
 
@@ -36,7 +36,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
  && yum clean all \
  && rm -rf /var/cache/yum
 
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev-x86_64-linux-gnu ${OPERATOR}
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev ${OPERATOR}
 COPY bin /usr/local/bin
 COPY library/k8s_status.py /usr/share/ansible/openshift/
 


### PR DESCRIPTION
Specifying -x86_64-linux-gnu in the make target causes GOARCH=amd64 to
be defined, resulting in exec format errors when built on other arches.

CC: @crawford 