### PR TITLE
ci/test/scaffolding: fix hybrid operator dependency resolution

### DIFF
--- a/ci/tests/scaffolding/e2e-ansible-scaffold-hybrid.sh
+++ b/ci/tests/scaffolding/e2e-ansible-scaffold-hybrid.sh
@@ -31,7 +31,12 @@ then
     exit 1
 fi
 
+# Fixup the operator-sdk dependency in go.mod
+sed -i -E '/github.com\/operator-framework\/operator-sdk .+/d' go.mod
 add_go_mod_replace "github.com/operator-framework/operator-sdk" "$ROOTDIR"
+go mod edit -require "github.com/operator-framework/operator-sdk@v0.0.0"
+go mod vendor
+
 # Build the project to resolve dependency versions in the modfile.
 go build ./...
 

--- a/ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
+++ b/ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
@@ -21,7 +21,12 @@ then
     exit 1
 fi
 
+# Fixup the operator-sdk dependency in go.mod
+sed -i -E '/github.com\/operator-framework\/operator-sdk .+/d' go.mod
 add_go_mod_replace "github.com/operator-framework/operator-sdk" "$ROOTDIR"
+go mod edit -require "github.com/operator-framework/operator-sdk@v0.0.0"
+go mod vendor
+
 # Build the project to resolve dependency versions in the modfile.
 go build ./...
 


### PR DESCRIPTION
**Description of the change:**
Updates scaffolding for hybrid operator images so that branch resolution in `go.mod` is not required.

**Motivation for the change:**
Since `-mod=vendor` is enabled, Go is unable to resolve a psuedo-version for the operator-sdk dependency. Since we use a `replace` line for operator-sdk anyway, we can set the `operator-sdk` require version to `v0.0.0`

