### PR TITLE
add helm image release files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,9 @@ test-e2e-ansible: image-build-ansible
 test-e2e-ansible2 test/e2e/ansible2:
 	./ci/tests/e2e-ansible.sh
 
+test-e2e-helm2 test/e2e/helm2:
+	./ci/tests/e2e-helm.sh
+
 test-e2e-ansible-molecule: image-build-ansible
 	./hack/tests/e2e-ansible-molecule.sh
 

--- a/release/helm/Dockerfile
+++ b/release/helm/Dockerfile
@@ -1,0 +1,25 @@
+FROM openshift/origin-release:golang-1.13 AS builder
+
+ENV GO111MODULE=on \
+    GOFLAGS=-mod=vendor
+
+COPY . /go/src/github.com/operator-framework/operator-sdk
+RUN cd /go/src/github.com/operator-framework/operator-sdk \
+ && make build/operator-sdk-dev VERSION=dev
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV OPERATOR=/usr/local/bin/helm-operator \
+    USER_UID=1001 \
+    USER_NAME=helm \
+    HOME=/opt/helm
+
+# install operator binary
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev ${OPERATOR}
+COPY bin /usr/local/bin
+
+RUN /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}

--- a/release/helm/bin/entrypoint
+++ b/release/helm/bin/entrypoint
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+exec ${OPERATOR} exec-entrypoint helm --watches-file=/opt/helm/watches.yaml $@

--- a/release/helm/bin/user_setup
+++ b/release/helm/bin/user_setup
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
+mkdir -p ${HOME}
+chown ${USER_UID}:0 ${HOME}
+chmod ug+rwx ${HOME}
+
+# no need for this script to remain in the image after running
+rm $0

--- a/release/helm/upstream.Dockerfile
+++ b/release/helm/upstream.Dockerfile
@@ -1,0 +1,26 @@
+FROM openshift/origin-release:golang-1.13 AS builder
+
+ENV GO111MODULE=on \
+    GOFLAGS=-mod=vendor
+
+COPY . /go/src/github.com/operator-framework/operator-sdk
+RUN cd /go/src/github.com/operator-framework/operator-sdk \
+ && rm -rf vendor/github.com/operator-framework/operator-sdk \
+ && make build/operator-sdk-dev VERSION=dev
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV OPERATOR=/usr/local/bin/helm-operator \
+    USER_UID=1001 \
+    USER_NAME=helm \
+    HOME=/opt/helm
+
+# install operator binary
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev ${OPERATOR}
+COPY release/helm/bin /usr/local/bin
+
+RUN /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
**Description of the change:**
- Add helm Dockerfiles for OCP releases
- Add Makefile target to OCP release ci test

**Motivation for the change:**
Create docker file for helm OKD and OCP downstream

**Local Test**

```
$ docker build -f release/helm/Dockerfile .
Sending build context to Docker daemon  116.6MB
Step 1/11 : FROM openshift/origin-release:golang-1.13 AS builder
 ---> 931fb4f9df6f
Step 2/11 : ENV GO111MODULE on GOFLAGS -mod=vendor
 ---> Using cache
 ---> 903304ef8374
Step 3/11 : COPY . /go/src/github.com/operator-framework/operator-sdk
 ---> Using cache
 ---> 31642428446d
Step 4/11 : RUN cd /go/src/github.com/operator-framework/operator-sdk  && make build/operator-sdk-dev VERSION=dev
 ---> Running in b82dfa37d44d
^Z
[3]+  Stopped                 docker build -f release/helm/Dockerfile .
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/ocp-release-operator-sdk (helm) $ docker build -f release/helm/upstream.Dockerfile .
Sending build context to Docker daemon  116.6MB
Step 1/11 : FROM openshift/origin-release:golang-1.13 AS builder
 ---> 931fb4f9df6f
Step 2/11 : ENV GO111MODULE on GOFLAGS -mod=vendor
 ---> Using cache
 ---> 903304ef8374
Step 3/11 : COPY . /go/src/github.com/operator-framework/operator-sdk
 ---> Using cache
 ---> 31642428446d
Step 4/11 : RUN cd /go/src/github.com/operator-framework/operator-sdk  && rm -rf vendor/github.com/operator-framework/operator-sdk  && make build/operator-sdk-dev VERSION=dev
 ---> Using cache
 ---> fe544354fba5
Step 5/11 : FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
latest: Pulling from ubi8/ubi-minimal
03e56b46bf0b: Pull complete 
3a13cc2f5d65: Pull complete 
Digest: sha256:9285da611437622492f9ef4229877efe302589f1401bbd4052e9bb261b3d4387
Status: Downloaded newer image for registry.access.redhat.com/ubi8/ubi-minimal:latest
 ---> db39bd4846dc
Step 6/11 : ENV OPERATOR /usr/local/bin/helm-operator USER_UID 1001 USER_NAME helm HOME /opt/helm
 ---> Running in 9035fb144dce
 ---> 09086ac6ce10
Removing intermediate container 9035fb144dce
Step 7/11 : COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev ${OPERATOR}
 ---> 7d1facbb6475
Step 8/11 : COPY release/helm/bin /usr/local/bin
 ---> 3bfc43f85b74
Step 9/11 : RUN /usr/local/bin/user_setup
 ---> Running in ac76f471811e
+ echo 'helm:x:1001:0:helm user:/opt/helm:/sbin/nologin'
+ mkdir -p /opt/helm
+ chown 1001:0 /opt/helm
+ chmod ug+rwx /opt/helm
+ rm /usr/local/bin/user_setup
 ---> 1234485fb6e2
Removing intermediate container ac76f471811e
Step 10/11 : ENTRYPOINT /usr/local/bin/entrypoint
 ---> Running in 44acd8b5c21d
 ---> 6c41756e0bf1
Removing intermediate container 44acd8b5c21d
Step 11/11 : USER ${USER_UID}
 ---> Running in 21085e37fe57
 ---> d3b8a46fe45c
Removing intermediate container 21085e37fe57
Successfully built d3b8a46fe45c

```