### PR TITLE
fix build and ci ocp for helm image

### DIFF
--- a/ci/dockerfiles/ansible-e2e.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e.Dockerfile
@@ -5,5 +5,4 @@ RUN ci/tests/scaffolding/e2e-ansible-scaffold.sh
 FROM osdk-ansible
 
 COPY --from=builder /ansible/memcached-operator/watches.yaml ${HOME}/watches.yaml
-
 COPY --from=builder /ansible/memcached-operator/roles/ ${HOME}/roles/

--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -61,13 +61,13 @@ remove_operator() {
     for cr in $(ls $OPERATORDIR/deploy/crds/*_cr.yaml) ; do
       kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/${cr}" || true
     done
-    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/operator.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/service_account.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/role.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/role_binding.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/ansible.example.com_foos_crd.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/network-policy.yaml"
+    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/operator.yaml"
 }
 
 test_operator() {

--- a/release/helm/Dockerfile
+++ b/release/helm/Dockerfile
@@ -16,7 +16,7 @@ ENV OPERATOR=/usr/local/bin/helm-operator \
 
 # install operator binary
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev ${OPERATOR}
-COPY bin /usr/local/bin
+COPY release/helm/bin /usr/local/bin
 
 RUN /usr/local/bin/user_setup
 


### PR DESCRIPTION
**Description of the change:**
- Fix permissions for ocp ci tests
- Fix docker image for ocp release
- Fix order of delete of files for ansible

**Motivation for the change:**

Errors in the OCP CI and to build helm docker image 

**NOTE**
Blocked  by the incident to pull image from `error: image "registry.svc.ci.openshift.org/ci-op-npnsk2i0/stable@sha256:595142acf537b1b17b8e340c2de6b73364c79034401d58f5b09dfbd6b742e5c8" `
checkout #incident-ci-registry  it's been mentioned multiple times there .
