### PR TITLE
fix /ci/tests/e2e-helm.sh

### DIFF
--- a/ci/dockerfiles/helm-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/helm-e2e-hybrid.Dockerfile
@@ -11,7 +11,7 @@ ENV OPERATOR=/usr/local/bin/helm-operator \
     HOME=/opt/helm
 
 COPY --from=builder /helm/nginx-operator/watches.yaml ${HOME}/watches.yaml
-COPY --from=builder /helm/nginx-operator/helm-charts/ ${HOME}/helm-charts
+COPY --from=builder /helm/nginx-operator/helm-charts/ ${HOME}/helm-charts/
 
 # install operator binary
 COPY --from=builder /nginx-operator ${OPERATOR}

--- a/ci/dockerfiles/helm-e2e.Dockerfile
+++ b/ci/dockerfiles/helm-e2e.Dockerfile
@@ -5,4 +5,4 @@ RUN ci/tests/scaffolding/e2e-helm-scaffold.sh
 FROM osdk-helm
 
 COPY --from=builder /helm/nginx-operator/watches.yaml ${HOME}/watches.yaml
-COPY --from=builder /helm/nginx-operator/helm-charts/ ${HOME}/helm-charts
+COPY --from=builder /helm/nginx-operator/helm-charts/ ${HOME}/helm-charts/


### PR DESCRIPTION
**Description of the change:**
Add the "/" in the path for charts 

**Motivation for the change:**
Fix the following issue: 

```
{"level":"error","ts":1584242724.9947443,"logger":"cmd","msg":"Failed to create new manager factories.","Namespace":"default","error":"invalid chart directory helm-charts/nginx: stat helm-charts/nginx: no such file or directory","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tsrc/github.com/operator-framework/operator-sdk/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/operator-framework/operator-sdk/pkg/helm.Run\n\tsrc/github.com/operator-framework/operator-sdk/pkg/helm/run.go:105\ngithub.com/operator-framework/operator-sdk/cmd/operator-sdk/execentrypoint.newRunHelmCmd.func1\n\tsrc/github.com/operator-framework/operator-sdk/cmd/operator-sdk/execentrypoint/helm.go:38\ngithub.com/spf13/cobra.(*Command).execute\n\tsrc/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:826\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tsrc/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:914\ngithub.com/spf13/cobra.(*Command).Execute\n\tsrc/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:864\nmain.main\n\tsrc/github.com/operator-framework/operator-sdk/cmd/operator-sdk/main.go:39\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}
Error: invalid chart directory helm-charts/nginx: stat helm-charts/nginx: no such file or directory
```
