### PR TITLE
small improvements fixes in the helm scripts used by the ci

### DIFF
--- a/ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
+++ b/ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
@@ -6,7 +6,9 @@ set -eux
 
 ROOTDIR="$(pwd)"
 HELMDIR="/go/src/github.com/helm-op"
+
 mkdir -p $HELMDIR
+cd $HELMDIR
 
 # create and build the operator
 pushd "$HELMDIR"

--- a/ci/tests/scaffolding/e2e-helm-scaffold.sh
+++ b/ci/tests/scaffolding/e2e-helm-scaffold.sh
@@ -4,4 +4,5 @@ set -eux
 mkdir -p /helm
 cd /helm
 
+# create and build the operator
 operator-sdk new nginx-operator --api-version=helm.example.com/v1alpha1 --kind=Nginx --type=helm


### PR DESCRIPTION
**Description of the change:**
- Improve issues logs in the scripts called 
- ensure dir where the project should be scaffolded. (as done for ansible)
- update ci/tests/e2e-helm.sh  to use oc project default (as done for ansible)

**Motivation for the change:**

Trying to solve:  https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/7420/rehearse-7420-pull-ci-openshift-ocp-release-operator-sdk-release-4.5-e2e-aws-helm/8/build-log.txt