### PR TITLE
Fix entrypoint command

### DIFF
--- a/release/ansible/bin/entrypoint
+++ b/release/ansible/bin/entrypoint
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 cd $HOME
-exec ${OPERATOR} exec-entrypoint ansible --watches-file=$HOME/watches.yaml $@
+exec ${OPERATOR} --watches-file=$HOME/watches.yaml $@

--- a/release/helm/bin/entrypoint
+++ b/release/helm/bin/entrypoint
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 cd $HOME
-exec ${OPERATOR} exec-entrypoint helm --watches-file=$HOME/watches.yaml $@
+exec ${OPERATOR} --watches-file=$HOME/watches.yaml $@


### PR DESCRIPTION
**Description of the change:**
Fixes the entrypoint command to run the operator

**Motivation for the change:**
All the Ansible Operator base images built from this repo are currently broken.
