### PR TITLE
Use ansible-operator binary not the operator-sdk

### DIFF
--- a/release/ansible/Dockerfile.rhel8
+++ b/release/ansible/Dockerfile.rhel8
@@ -5,7 +5,7 @@ ENV GO111MODULE=on \
 
 COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
- && make build/operator-sdk-dev VERSION=dev
+ && make build/ansible-operator VERSION=$(git describe --tags --always)
 
 FROM registry.access.redhat.com/ubi8/ubi
 
@@ -33,7 +33,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 
 COPY release/ansible/ansible_collections ${HOME}/.ansible/collections/ansible_collections
 
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk-dev ${OPERATOR}
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/ansible-operator ${OPERATOR}
 COPY release/ansible/bin /usr/local/bin
 
 RUN /usr/local/bin/user_setup


### PR DESCRIPTION
Dockerfile.rhel8 had the older format before we split to use ansible-operator. This will fix the flag error from CI:

   Error: unknown flag: --watches-file