### PR TITLE
Updating openshift-enterprise-helm-operator builder & base images to be consistent with ART

### DIFF
--- a/release/helm/Dockerfile
+++ b/release/helm/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 ENV GO111MODULE=on \
     GOFLAGS=-mod=vendor
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
  && make build/helm-operator VERSION=$(git describe --tags --always)
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_UID=1001 \


### PR DESCRIPTION
Updating openshift-enterprise-helm-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/openshift-enterprise-helm-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.