### PR TITLE
Bug 1915871: Fix the operator-sdk version on the image

### DIFF
--- a/patches/03-setversion.patch
+++ b/patches/03-setversion.patch
@@ -1,14 +1,14 @@
 diff -up ./Makefile.setversion ./Makefile
---- ./Makefile.setversion	2020-12-17 11:54:04.395182503 -0500
-+++ ./Makefile	2020-12-17 11:54:34.314584114 -0500
+--- ./Makefile.setversion	2021-01-18 18:00:48.798480030 -0500
++++ ./Makefile	2021-01-18 18:01:39.492178121 -0500
 @@ -6,8 +6,8 @@ SHELL = /bin/bash
  # version is moved to a separate repo and release process.
- export IMAGE_VERSION = v1.2.0
+ export IMAGE_VERSION = v1.3.0
  # Build-time variables to inject into binaries
 -export SIMPLE_VERSION = $(shell (test "$(shell git describe)" = "$(shell git describe --abbrev=0)" && echo $(shell git describe)) || echo $(shell git describe --abbrev=0)+git)
 -export GIT_VERSION = $(shell git describe --dirty --tags --always)
-+export SIMPLE_VERSION = v1.2.0-ocp
++export SIMPLE_VERSION = v1.3.0-ocp
 +export GIT_VERSION = $(SIMPLE_VERSION)
  export GIT_COMMIT = $(shell git rev-parse HEAD)
- export K8S_VERSION = 1.18.8
+ export K8S_VERSION = 1.19.4
  

--- a/release/sdk/Dockerfile
+++ b/release/sdk/Dockerfile
@@ -5,7 +5,7 @@ ENV GO111MODULE=on \
 
 COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
- && make build/operator-sdk
+ && make -f ci/prow.Makefile patch build
 
 FROM registry.svc.ci.openshift.org/ocp/4.7:base
 


### PR DESCRIPTION
The operator-sdk version for downstream should not be v4.7.0 or dirty.

```
$ docker run -it --entrypoint=/bin/sh --user 1000:0 registry.build01.ci.openshift.org/ci-op-6qx8ss8d/stable:operator-sdk
sh-4.4$ operator-sdk version
operator-sdk version: "7ead15f5-dirty", commit: "7ead15f5713d34654270b7c9fb64ecedcd176d8e", kubernetes version: "v1.19.4", go version: "go1.15.5", GOOS: "linux", GOARCH: "amd64"
```
