### PR TITLE
Bug 1966759: OpenShift plugin adds OCP-specific configuration to projects

### DIFF
--- a/internal/plugins/openshift/v1/init.go
+++ b/internal/plugins/openshift/v1/init.go
@@ -1,0 +1,111 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"github.com/spf13/afero"
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+const (
+	// The current OCP release version.
+	ocpProductVersion = "4.8"
+	// The currently used version of ubi8/ubi-minimal images.
+	ubiMinimalVersion = "8.3"
+)
+
+type initSubcommand struct {
+	config config.Config
+}
+
+func (s *initSubcommand) InjectConfig(c config.Config) error {
+	s.config = c
+	return nil
+}
+
+// Scaffold updates a newly initialized project with OpenShift-specific configuration.
+func (s *initSubcommand) Scaffold(fs machinery.Filesystem) error {
+	if err := replaceImages(fs); err != nil {
+		return err
+	}
+
+	// Update the plugin config section with this plugin's configuration.
+	if err := s.config.EncodePluginConfig(pluginKey, Config{}); err != nil && !errors.As(err, &config.UnsupportedFieldError{}) {
+		return fmt.Errorf("error writing plugin config for %s: %v", pluginKey, err)
+	}
+
+	return nil
+}
+
+type substitution struct {
+	fromTagRE *regexp.Regexp
+	toTag     string
+}
+
+// imageSubstitutions is a map of paths to image substitutions.
+var imageSubstitutions = map[string][]substitution{
+	filepath.Join("config", "default", "manager_auth_proxy_patch.yaml"): {
+		{
+			regexp.MustCompile(`gcr.io/kubebuilder/kube-rbac-proxy:[^ \n]+`),
+			"registry.redhat.io/openshift4/ose-kube-rbac-proxy:v" + ocpProductVersion,
+		},
+	},
+	filepath.Join("Dockerfile"): {
+		// Ansible
+		{
+			regexp.MustCompile(`quay.io/operator-framework/ansible-operator:[^ \n]+`),
+			"registry.redhat.io/openshift4/ose-ansible-operator:v" + ocpProductVersion,
+		},
+		// Helm
+		{
+			regexp.MustCompile(`quay.io/operator-framework/helm-operator:[^ \n]+`),
+			"registry.redhat.io/openshift4/ose-helm-operator:v" + ocpProductVersion,
+		},
+		// Go
+		{
+			regexp.MustCompile(`gcr.io/distroless/static:[^ \n]+`),
+			"registry.access.redhat.com/ubi8/ubi-minimal:" + ubiMinimalVersion,
+		},
+	},
+}
+
+// replaceImages replaces upstream images with their downstream (OpenShift) equivalents.
+func replaceImages(fs machinery.Filesystem) error {
+
+	for filePath, substitutions := range imageSubstitutions {
+		b, err := afero.ReadFile(fs.FS, filePath)
+		if err != nil {
+			return fmt.Errorf("error reading file for substitution: %v", err)
+		}
+		info, err := fs.FS.Stat(filePath)
+		if err != nil {
+			return fmt.Errorf("error reading file info for substitution: %v", err)
+		}
+		for _, subst := range substitutions {
+			b = subst.fromTagRE.ReplaceAll(b, []byte(subst.toTag))
+		}
+		if err = afero.WriteFile(fs.FS, filePath, b, info.Mode()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/plugins/openshift/v1/init_test.go
+++ b/internal/plugins/openshift/v1/init_test.go
@@ -1,0 +1,123 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+
+	"github.com/spf13/afero"
+)
+
+var _ = Describe("RunInit", func() {
+
+	Describe("replaceImages", func() {
+		var (
+			fs machinery.Filesystem
+
+			dockerfilePath = "Dockerfile"
+			proxyPatchPath = "config/default/manager_auth_proxy_patch.yaml"
+		)
+
+		BeforeEach(func() {
+			fs = machinery.Filesystem{FS: afero.NewMemMapFs()}
+		})
+
+		It("substitutes all images correctly", func() {
+			Expect(afero.WriteFile(fs.FS, dockerfilePath, []byte(dockerfileAll), 0644)).To(Succeed())
+			Expect(afero.WriteFile(fs.FS, proxyPatchPath, []byte(proxyPatch), 0644)).To(Succeed())
+			Expect(replaceImages(fs)).To(Succeed())
+			dockerfileOut, err := afero.ReadFile(fs.FS, dockerfilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(dockerfileOut)).To(ContainSubstring(dockerfileAllExp), "Dockerfile match")
+			proxyPatchOut, err := afero.ReadFile(fs.FS, proxyPatchPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(proxyPatchOut)).To(ContainSubstring(proxyPatchExp), "manager_auth_proxy_patch.yaml match")
+		})
+	})
+})
+
+const dockerfileAll = `FROM foo:bar
+
+FROM quay.io/operator-framework/ansible-operator:v1.2.3
+FROM quay.io/operator-framework/ansible-operator:v1.2
+FROM quay.io/operator-framework/ansible-operator:latest
+FROM quay.io/operator-framework/ansible:latest
+FROM foo/ansible-operator:latest
+
+FROM quay.io/operator-framework/helm-operator:v1.2.3
+FROM quay.io/operator-framework/helm-operator:v1.2
+FROM quay.io/operator-framework/helm-operator:latest
+FROM quay.io/operator-framework/helm:latest
+FROM foo/helm-operator:latest
+
+FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:latest
+FROM distroless/static:latest
+`
+
+const dockerfileAllExp = `FROM foo:bar
+
+FROM registry.redhat.io/openshift4/ose-ansible-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-ansible-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-ansible-operator:v` + ocpProductVersion + `
+FROM quay.io/operator-framework/ansible:latest
+FROM foo/ansible-operator:latest
+
+FROM registry.redhat.io/openshift4/ose-helm-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-helm-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-helm-operator:v` + ocpProductVersion + `
+FROM quay.io/operator-framework/helm:latest
+FROM foo/helm-operator:latest
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:` + ubiMinimalVersion + `
+FROM registry.access.redhat.com/ubi8/ubi-minimal:` + ubiMinimalVersion + `
+FROM distroless/static:latest
+`
+
+const proxyPatch = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+      - name: kube-rbac-proxy-latest
+        image: gcr.io/kubebuilder/kube-rbac-proxy:latest
+      - name: upstream
+        image: quay.io/brancz/kube-rbac-proxy:v0.5.0
+`
+
+const proxyPatchExp = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v` + ocpProductVersion + `
+      - name: kube-rbac-proxy-latest
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v` + ocpProductVersion + `
+      - name: upstream
+        image: quay.io/brancz/kube-rbac-proxy:v0.5.0
+`

--- a/internal/plugins/openshift/v1/plugin.go
+++ b/internal/plugins/openshift/v1/plugin.go
@@ -1,0 +1,49 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	cfgv2 "sigs.k8s.io/kubebuilder/v3/pkg/config/v2"
+	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+
+	"github.com/operator-framework/operator-sdk/internal/plugins"
+)
+
+const pluginName = "openshift" + plugins.DefaultNameQualifier
+
+var (
+	pluginVersion            = plugin.Version{Number: 1}
+	supportedProjectVersions = []config.Version{cfgv2.Version, cfgv3.Version}
+	pluginKey                = plugin.KeyFor(Plugin{})
+)
+
+var (
+	_ plugin.Plugin = Plugin{}
+	_ plugin.Init   = Plugin{}
+)
+
+type Plugin struct {
+	initSubcommand
+}
+
+func (Plugin) Name() string                               { return pluginName }
+func (Plugin) Version() plugin.Version                    { return pluginVersion }
+func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }
+func (p Plugin) GetInitSubcommand() plugin.InitSubcommand { return &p.initSubcommand }
+
+// Config configures this plugin, and is saved in the project config file.
+type Config struct{}

--- a/internal/plugins/openshift/v1/plugin.go
+++ b/internal/plugins/openshift/v1/plugin.go
@@ -19,11 +19,9 @@ import (
 	cfgv2 "sigs.k8s.io/kubebuilder/v3/pkg/config/v2"
 	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
-
-	"github.com/operator-framework/operator-sdk/internal/plugins"
 )
 
-const pluginName = "openshift" + plugins.DefaultNameQualifier
+const pluginName = "sdk.x-openshift.io"
 
 var (
 	pluginVersion            = plugin.Version{Number: 1}

--- a/internal/plugins/openshift/v1/suite_test.go
+++ b/internal/plugins/openshift/v1/suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOpenshiftV1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "openshift/v1 Suite")
+}

--- a/patches/11-openshiftv1-cli.patch
+++ b/patches/11-openshiftv1-cli.patch
@@ -1,0 +1,33 @@
+diff -up internal/cmd/operator-sdk/cli/cli.go.patchocpv1 internal/cmd/operator-sdk/cli/cli.go
+--- internal/cmd/operator-sdk/cli/cli.go.patchocpv1	2021-06-01 09:07:16.690850490 -0700
++++ internal/cmd/operator-sdk/cli/cli.go	2021-06-01 09:07:22.057927153 -0700
+@@ -43,6 +43,7 @@ import (
+ 	envtestv1 "github.com/operator-framework/operator-sdk/internal/plugins/envtest/v1"
+ 	helmv1 "github.com/operator-framework/operator-sdk/internal/plugins/helm/v1"
+ 	manifestsv2 "github.com/operator-framework/operator-sdk/internal/plugins/manifests/v2"
++	openshiftv1 "github.com/operator-framework/operator-sdk/internal/plugins/openshift/v1"
+ 	scorecardv2 "github.com/operator-framework/operator-sdk/internal/plugins/scorecard/v2"
+ 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+ )
+@@ -84,18 +85,21 @@ func GetPluginsCLIAndRoot() (*cli.CLI, *
+ 		golangv3.Plugin{},
+ 		manifestsv2.Plugin{},
+ 		scorecardv2.Plugin{},
++		openshiftv1.Plugin{},
+ 	)
+ 	ansibleBundle, _ := plugin.NewBundle("ansible"+plugins.DefaultNameQualifier, plugin.Version{Number: 1},
+ 		kustomizev1.Plugin{},
+ 		ansiblev1.Plugin{},
+ 		manifestsv2.Plugin{},
+ 		scorecardv2.Plugin{},
++		openshiftv1.Plugin{},
+ 	)
+ 	helmBundle, _ := plugin.NewBundle("helm"+plugins.DefaultNameQualifier, plugin.Version{Number: 1},
+ 		kustomizev1.Plugin{},
+ 		helmv1.Plugin{},
+ 		manifestsv2.Plugin{},
+ 		scorecardv2.Plugin{},
++		openshiftv1.Plugin{},
+ 	)
+ 	c, err := cli.New(
+ 		cli.WithCommandName("operator-sdk"),


### PR DESCRIPTION
**Description of the change:**
- internal/plugins/openshift: add OpenShift plugin to add OCP-specificconfiguration to projects
- internal/plugins/{go,ansible,helm}: run openshift/v1 phase 2 init plugin

**Motivation for the change:** some OCP-specific images need to be substituted for upstream ones. A phase 2 plugin accomplishes this for all plugins regardless of origin.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
