### PR TITLE
Bug 1917765: patch the Makefile before building ansible & helm operators

### DIFF
--- a/ci/prow.Makefile
+++ b/ci/prow.Makefile
@@ -13,8 +13,7 @@ patch:
 	for i in ./patches/*.patch; do patch -p0 < $$i; done
 
 build:
-	@echo "building sdk"
-	$(MAKE) -f Makefile build/operator-sdk
+	$(MAKE) -f Makefile build/operator-sdk build/ansible-operator build/helm-operator
 
 test-e2e-go:
 	./ci/tests/e2e-go.sh $(ARGS)

--- a/release/ansible/Dockerfile.rhel8
+++ b/release/ansible/Dockerfile.rhel8
@@ -3,9 +3,10 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 
 ENV GO111MODULE=on \
     GOFLAGS=-mod=vendor
 
+# we need to patch the Makefile prior to building
 COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
- && make build/ansible-operator
+ && make -f ci/prow.Makefile patch build
 
 FROM registry.svc.ci.openshift.org/ocp/4.7:base
 

--- a/release/helm/Dockerfile
+++ b/release/helm/Dockerfile
@@ -3,9 +3,10 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS b
 ENV GO111MODULE=on \
     GOFLAGS=-mod=vendor
 
+# we need to patch the Makefile prior to building
 COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
- && make build/helm-operator
+ && make -f ci/prow.Makefile patch build
 
 FROM registry.ci.openshift.org/ocp/4.7:base
 


### PR DESCRIPTION
The ansible and helm operator binaries print out the openshift release version which will cause collisions with upstream versions. We want he version to match upstream with an added `ocp` tag to make it known this was an ocp build.