### PR TITLE
Bug 1921458: `run bundle-upgrade` should handle error gracefully when a previous operator version doesn't exist

### DIFF
--- a/patches/04-bug1921458.patch
+++ b/patches/04-bug1921458.patch
@@ -1,0 +1,23 @@
+diff -up ./internal/olm/operator/registry/operator_installer.go.bug1921458 ./internal/olm/operator/registry/operator_installer.go
+--- ./internal/olm/operator/registry/operator_installer.go.bug1921458	2021-01-29 10:04:18.358090742 -0500
++++ ./internal/olm/operator/registry/operator_installer.go	2021-01-29 10:05:27.578027432 -0500
+@@ -16,6 +16,7 @@ package registry
+ 
+ import (
+ 	"context"
++	"errors"
+ 	"fmt"
+ 	"time"
+ 
+@@ -108,6 +109,11 @@ func (o OperatorInstaller) UpgradeOperat
+ 		return nil, fmt.Errorf("error getting list of subscriptions: %v", err)
+ 	}
+ 
++	// If there are no subscriptions found, then the previous operator version doesn't exist, so return error
++	if len(subList.Items) == 0 {
++		return nil, errors.New("no existing operator found in the cluster to upgrade")
++	}
++
+ 	var subscription *v1alpha1.Subscription
+ 	for i := range subList.Items {
+ 		s := subList.Items[i]

--- a/patches/05-handle-sub-pkg-name-mismatch.patch
+++ b/patches/05-handle-sub-pkg-name-mismatch.patch
@@ -1,0 +1,14 @@
+diff -up ./internal/olm/operator/registry/operator_installer.go.handle-sub-pkg-name-mismatch ./internal/olm/operator/registry/operator_installer.go
+--- ./internal/olm/operator/registry/operator_installer.go.handle-sub-pkg-name-mismatch	2021-01-29 11:06:12.280775956 -0500
++++ ./internal/olm/operator/registry/operator_installer.go	2021-01-29 11:06:22.426912376 -0500
+@@ -123,6 +123,10 @@ func (o OperatorInstaller) UpgradeOperat
+ 		}
+ 	}
+ 
++	if subscription == nil {
++		return nil, fmt.Errorf("subscription for package %q not found", o.PackageName)
++	}
++
+ 	log.Infof("Found existing subscription with name %s and namespace %s", subscription.Name, subscription.Namespace)
+ 
+ 	// todo: attempt #1 to trigger install plan for the subscription and


### PR DESCRIPTION
**Description of the change:**
`run bundle-upgrade` command handles error instead of throwing a panic, when a previous version of the operator bundle doesn't exist in the cluster 

**Motivation for the change:**
```
Without installing etcd operator, 
# operator-sdk run bundle-upgrade quay.io/olmqe/etcd-bundle:0.9.2-share

Result:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1978d29]
```

Expected behavior: The command should check that the etcd operator doesn't exist in the cluster and handle the error gracefully instead of throwing a panic.
