### PR TITLE
Bug 2058044: use ubi instead of busybox for untar image

### DIFF
--- a/ci/prow.Makefile
+++ b/ci/prow.Makefile
@@ -15,10 +15,10 @@ patch:
 build:
 	$(MAKE) -f Makefile build/operator-sdk build/ansible-operator build/helm-operator build-darwin
 
-test-e2e-go:
+test-e2e-go: patch
 	./ci/tests/e2e-go.sh $(ARGS)
 
-test-e2e-ansible:
+test-e2e-ansible: patch
 	./ci/tests/e2e-ansible-scaffolding.sh
 
 #test-e2e-ansible test/e2e/ansible:test-scaffolding-e2e-ansible
@@ -31,7 +31,7 @@ test-e2e-helm: patch
 	./ci/tests/e2e-helm.sh
 	#./hack/tests/e2e-helm.sh
 
-test-subcommand:
+test-subcommand: patch
 	./ci/tests/subcommand.sh
 
 ci-images:

--- a/patches/14-bug2058044-use-ubi-for-untar.patch
+++ b/patches/14-bug2058044-use-ubi-for-untar.patch
@@ -1,0 +1,12 @@
+diff -up ./internal/scorecard/testpod.go.bug2058044 ./internal/scorecard/testpod.go
+--- ./internal/scorecard/testpod.go.bug2058044	2022-03-15 14:26:01.317298424 -0400
++++ ./internal/scorecard/testpod.go	2022-03-15 14:29:43.240764199 -0400
+@@ -33,7 +33,7 @@ const (
+ 
+ 	// The image used to untar bundles prior to running tests within a runner Pod.
+ 	// This image tag should always be pinned to a specific version.
+-	scorecardUntarImage = "docker.io/busybox:1.33.0"
++	scorecardUntarImage = "registry.access.redhat.com/ubi8/ubi:8.4"
+ )
+ 
+ // getPodDefinition fills out a Pod definition based on


### PR DESCRIPTION
**Description of the change:**
Switch to using UBI instead of busybox for the untar image.

**Motivation for the change:**
With the docker rate limiting in place, busybox is not a great choice
for the untar image. Therefore, switching to UBI to avoid that limit.
