### PR TITLE
Add darwin/arm64 binaries

### DIFF
--- a/patches/06-build-darwin-binary.patch
+++ b/patches/06-build-darwin-binary.patch
@@ -1,12 +1,13 @@
 diff -up ./Makefile.darwin ./Makefile
 --- ./Makefile.darwin	2021-02-18 12:02:57.158711869 -0500
 +++ ./Makefile	2021-02-18 12:10:11.759446770 -0500
-@@ -177,3 +177,8 @@ help: ## Show this help screen.
+@@ -195,3 +195,9 @@ help: ## Show this help screen.
  	@echo 'Available targets are:'
  	@echo ''
  	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 +
 +.PHONY: build-darwin
 +build-darwin: ## Build operator-sdk, ansible-operator, and helm-operator.
-+	@mkdir -p $(BUILD_DIR)/darwin_amd64
++	@mkdir -p $(BUILD_DIR)/darwin_amd64 $(BUILD_DIR)/darwin_arm64
 +	GOOS=darwin GOARCH=amd64 go build $(GO_BUILD_ARGS) -o $(BUILD_DIR)/darwin_amd64/ ./cmd/operator-sdk
++	GOOS=darwin GOARCH=arm64 go build $(GO_BUILD_ARGS) -o $(BUILD_DIR)/darwin_arm64/ ./cmd/operator-sdk

--- a/release/sdk/Dockerfile
+++ b/release/sdk/Dockerfile
@@ -23,6 +23,7 @@ ENV USER_UID=1001 \
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk /usr/local/bin/operator-sdk
 # copy the mac binary to the image
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/darwin_amd64/operator-sdk /usr/share/operator-sdk/mac/operator-sdk
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/darwin_arm64/operator-sdk /usr/share/operator-sdk/mac_arm64/operator-sdk
 COPY release/sdk/bin /usr/local/bin
 RUN /usr/local/bin/user_setup
 


### PR DESCRIPTION
**Description of the change:**
Add darwin/arm64 to OCP operator-sdk artifacts.

**Motivation for the change:**
The latest MacOS systems are being built with the ARM architecture.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
