### PR TITLE
OCPBUGS-16138: fix 03-setversion.patch

### DIFF
--- a/patches/03-setversion.patch
+++ b/patches/03-setversion.patch
@@ -7,7 +7,7 @@ diff -up ./Makefile.setversion ./Makefile
  # Build-time variables to inject into binaries
 -export SIMPLE_VERSION = $(shell (test "$(shell git describe --tags)" = "$(shell git describe --tags --abbrev=0)" && echo $(shell git describe --tags)) || echo $(shell git describe --tags --abbrev=0)+git)
 -export GIT_VERSION = $(shell git describe --dirty --tags --always)
-+export SIMPLE_VERSION = v1.28.0-ocp
++export SIMPLE_VERSION = v1.30.0-ocp
 +export GIT_VERSION = $(SIMPLE_VERSION)
  export GIT_COMMIT = $(shell git rev-parse HEAD)
  export K8S_VERSION = 1.25.0


### PR DESCRIPTION
Fixes `patches/03-setversion.patch` to have the correct version of `v1.30.0-ocp`