### PR TITLE
OCPBUGS-15801: add image replacement for hybrid helm plugin Dockerfile

### DIFF
--- a/internal/plugins/openshift/v1/init.go
+++ b/internal/plugins/openshift/v1/init.go
@@ -84,6 +84,11 @@ var imageSubstitutions = map[string][]substitution{
 			regexp.MustCompile(`gcr.io/distroless/static:[^ \n]+`),
 			"registry.access.redhat.com/ubi8/ubi-minimal:" + ubiMinimalVersion,
 		},
+		// Hybrid Helm
+		{
+			regexp.MustCompile(`registry.access.redhat.com/ubi8/ubi-micro:[^ \n]+`),
+			"registry.access.redhat.com/ubi8/ubi-micro:" + ubiMinimalVersion,
+		},
 	},
 }
 

--- a/internal/plugins/openshift/v1/init_test.go
+++ b/internal/plugins/openshift/v1/init_test.go
@@ -67,6 +67,8 @@ FROM foo/helm-operator:latest
 FROM gcr.io/distroless/static:nonroot
 FROM gcr.io/distroless/static:latest
 FROM distroless/static:latest
+
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.1
 `
 
 const dockerfileAllExp = `FROM foo:bar
@@ -86,6 +88,8 @@ FROM foo/helm-operator:latest
 FROM registry.access.redhat.com/ubi8/ubi-minimal:` + ubiMinimalVersion + `
 FROM registry.access.redhat.com/ubi8/ubi-minimal:` + ubiMinimalVersion + `
 FROM distroless/static:latest
+
+FROM registry.access.redhat.com/ubi8/ubi-micro:` + ubiMinimalVersion + `
 `
 
 const proxyPatch = `apiVersion: apps/v1


### PR DESCRIPTION
**Description of the change:**
- Adds image replacement for the hybrid helm plugin's scaffolded Dockerfile

**Motivation for the change:**
- OCPBUGS-15801
