### PR TITLE
OCPBUGS-: update openshift plugin for CVE-2023-44487 & CVE-2023-39325

### DIFF
--- a/internal/plugins/openshift/v1/init.go
+++ b/internal/plugins/openshift/v1/init.go
@@ -84,10 +84,40 @@ var imageSubstitutions = map[string][]substitution{
 			regexp.MustCompile(`gcr.io/distroless/static:[^ \n]+`),
 			"registry.access.redhat.com/ubi8/ubi-minimal:" + ubiMinimalVersion,
 		},
+		// Go - for https://access.redhat.com/security/cve/CVE-2023-44487 &&
+		// https://access.redhat.com/security/cve/CVE-2023-39325 .
+		// This will ensure all Go projects have their Dockerfile updated to use
+		// Go 1.20+ as the builder image. This should be removed when the default
+		// scaffolds are updated to be Go 1.20+
+		{
+			regexp.MustCompile(`golang:[^ \n]+`),
+			"golang:1.20",
+		},
 		// Hybrid Helm
 		{
 			regexp.MustCompile(`registry.access.redhat.com/ubi8/ubi-micro:[^ \n]+`),
 			"registry.access.redhat.com/ubi8/ubi-micro:" + ubiMinimalVersion,
+		},
+	},
+
+	filepath.Join("go.mod"): {
+		// Go - for https://access.redhat.com/security/cve/CVE-2023-44487 &&
+		// https://access.redhat.com/security/cve/CVE-2023-39325 .
+		// This will ensure all Go projects have their go.mod updated to use
+		// golang.org/x/net v0.17.0. This should be removed when the default
+		// scaffolds are updated to use this by default
+		{
+			regexp.MustCompile(`golang.org/x/net [^ \n]+`),
+			"golang.org/x/net v0.17.0",
+		},
+		// Go - for https://access.redhat.com/security/cve/CVE-2023-44487 &&
+		// https://access.redhat.com/security/cve/CVE-2023-39325 .
+		// This will ensure all Go projects have their go.mod updated to use
+		// go 1.20+. This should be removed when the default
+		// scaffolds are updated to use this by default
+		{
+			regexp.MustCompile(`go 1.[^2\n]+`),
+			"go 1.20",
 		},
 	},
 }


### PR DESCRIPTION
**Description of the change:**
- Updates the `openshift` plugin to:
    - replace all `golang:*` builder stage images with `golang:1.20` in scaffolded Dockerfile
    - replace `go 1.y` with `go 1.20` if y < 20 in scaffoled go.mod
    - replace `golang.org/x/net *` with `golang.org/x/net v0.17.0` in scaffolded go.mod

**Motivation for the change:**
- Address https://access.redhat.com/security/cve/CVE-2023-44487 and https://access.redhat.com/security/cve/CVE-2023-39325 in the default scaffolds of the Go plugin

> [!Warning]
> This does _not_ update or guarantee that the operator-sdk binary itself is being built with a fixed version of Go and `golang.org/x/net v0.17.0` and will still need to be done in a separate pull request to fully address these CVEs

**Additional Context**
I've manually verified that this works on this branch by building the operator-sdk binary with:
```
$ make -f ci/prow.Makefile patch build
```
and creating a minimal go/v3 project (in a separate directory):
```
$ go mod init example.com

$ /Users/bpalmer/github/ocp-release-operator-sdk/build/operator-sdk init --domain example.org
```

Verification of changes taking place:
```
$ cat Dockerfile
# Build the manager binary
FROM golang:1.20 as builder
...

$ cat go.mod | grep -i go
go 1.20
...

$ cat go.mod | grep -i golang.org/x/net
	golang.org/x/net v0.17.0 // indirect

$ cat go.sum | grep -i golang.org/x/net
...
golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
```
