### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -43,8 +43,8 @@ jobs:
         if [[ "$TAG" == "" ]]; then
           TAG="$(git branch --show-current)-${GIT_COMMIT}"
         fi
-        echo "tag=${IMG}:${TAG}" >> $GITHUB_OUTPUT
-        echo "git_commit=${GIT_COMMIT}" >> $GITHUB_OUTPUT
+        echo "tag=${IMG}:${TAG}" >> "$GITHUB_OUTPUT"
+        echo "git_commit=${GIT_COMMIT}" >> "$GITHUB_OUTPUT"
 
     - name: build and push ansible dep image
       uses: docker/build-push-action@v3
@@ -66,7 +66,7 @@ jobs:
         sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-base:.+|FROM ${{ steps.base_tag.outputs.tag }}|g' images/ansible-operator/Dockerfile
         git diff --exit-code --quiet && echo "Failed to update images/ansible-operator/Dockerfile" && exit 1
         REF="${{ github.event.ref }}"
-        echo "branch_name=${REF##*/}" >> $GITHUB_OUTPUT
+        echo "branch_name=${REF##*/}" >> "$GITHUB_OUTPUT"
 
     - name: create PR for ansible-operator Dockerfile
       uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
       id: tags
       run: |
         IMG=quay.io/${{ github.repository_owner }}/${{ matrix.id }}
-        echo "tags=$(.github/workflows/get_image_tags.sh "$IMG" "v")" >> $GITHUB_OUTPUT
+        echo "tags=$(.github/workflows/get_image_tags.sh "$IMG" "v")" >> "$GITHUB_OUTPUT"
 
     - name: build and push
       uses: docker/build-push-action@v3
@@ -146,7 +146,7 @@ jobs:
       id: tags
       run: |
         IMG=quay.io/${{ github.repository_owner }}/scorecard-test-kuttl
-        echo "tags=$(.github/workflows/get_image_tags.sh "$IMG" "scorecard-kuttl/v")" >> $GITHUB_OUTPUT
+        echo "tags=$(.github/workflows/get_image_tags.sh "$IMG" "scorecard-kuttl/v")" >> "$GITHUB_OUTPUT"
 
     - name: build and push
       uses: docker/build-push-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
+          echo "skip=$(.github/workflows/check-docs-only.sh $REF)" >> $GITHUB_ENV
 
   # Job to test release steps. This will only create a release remotely if run on a tagged commit.
   goreleaser:
@@ -100,7 +100,7 @@ jobs:
       id: tags
       run: |
         IMG=quay.io/${{ github.repository_owner }}/${{ matrix.id }}
-        echo ::set-output name=tags::$(.github/workflows/get_image_tags.sh "$IMG" "v")
+        echo "tags=$(.github/workflows/get_image_tags.sh "$IMG" "v")" >> $GITHUB_OUTPUT
 
     - name: build and push
       uses: docker/build-push-action@v3
@@ -146,7 +146,7 @@ jobs:
       id: tags
       run: |
         IMG=quay.io/${{ github.repository_owner }}/scorecard-test-kuttl
-        echo ::set-output name=tags::$(.github/workflows/get_image_tags.sh "$IMG" "scorecard-kuttl/v")
+        echo "tags=$(.github/workflows/get_image_tags.sh "$IMG" "scorecard-kuttl/v")" >> $GITHUB_OUTPUT
 
     - name: build and push
       uses: docker/build-push-action@v3

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         fetch-depth: 0
     - id: tags
-      run: echo "git_tags=$(.github/workflows/freshen-images/tags.sh)" >> $GITHUB_OUTPUT
+      run: echo "git_tags=$(.github/workflows/freshen-images/tags.sh)" >> "$GITHUB_OUTPUT"
 
   build:
     name: build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
+          echo "skip=$(.github/workflows/check-docs-only.sh $REF)" >> $GITHUB_ENV
 
   integration:
     name: integration

--- a/.github/workflows/test-ansible.yml
+++ b/.github/workflows/test-ansible.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
+          echo "skip=$(.github/workflows/check-docs-only.sh $REF)" >> $GITHUB_ENV
 
   e2e:
     name: e2e

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
+          echo "skip=$(.github/workflows/check-docs-only.sh $REF)" >> $GITHUB_ENV
 
   e2e:
     name: e2e

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
+          echo "skip=$(.github/workflows/check-docs-only.sh $REF)" >> $GITHUB_ENV
 
   e2e:
     name: e2e

--- a/.github/workflows/test-sample-go.yml
+++ b/.github/workflows/test-sample-go.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
+          echo "skip=$(.github/workflows/check-docs-only.sh $REF)" >> $GITHUB_ENV
 
   e2e:
     name: e2e

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         REF="HEAD^"
         [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-        echo "skip=$(.github/workflows/check-docs-only.sh $REF)" >> $GITHUB_OUTPUT
+        echo "skip=$(.github/workflows/check-docs-only.sh $REF)" >> "$GITHUB_OUTPUT"
 
   sanity:
     name: sanity


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


