### PR TITLE
OCPBUGS-38976: Change base image of operator-sdk from rhel8 to rhel9

### DIFF
--- a/release/sdk/Dockerfile
+++ b/release/sdk/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/operator-framework/operator-sdk
 RUN cd /go/src/github.com/operator-framework/operator-sdk \
  && make -f ci/prow.Makefile patch build
 
-FROM registry.ci.openshift.org/ocp/4.17:base
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 RUN yum install -y \
       golang \


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Change base image of operator-sdk from rhel8 to rhel9

**Motivation for the change:**
The operator-sdk release Dockerfile (https://github.com/openshift/ocp-release-operator-sdk/blob/2fcf5f0457f4aaccf3043cd99488b1d5050deada/release/sdk/Dockerfile) uses rhel9 based builder image, but uses rhel8 based base image. This may lead to version mismatch of GLIBC and end up in runtime error.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
