### PR TITLE
OCPBUGS-37598: UPSTREAM: <carry>: Remove unused symlink of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-release/ansible/Dockerfile


### PR DESCRIPTION
This PR removes the symlink of the Dockerfile to the removed `release/ansible/Dockerfile`. This file is unused and should be removed as it is causing image build issues.