### PR TITLE
OCPBUGS-42425: Update base image of scaffolded Dockerfile for helm-operator to use rhel9 repository

### DIFF
--- a/internal/plugins/openshift/v1/init.go
+++ b/internal/plugins/openshift/v1/init.go
@@ -77,7 +77,7 @@ var imageSubstitutions = map[string][]substitution{
 		// Helm
 		{
 			regexp.MustCompile(`quay.io/operator-framework/helm-operator:[^ \n]+`),
-			"registry.redhat.io/openshift4/ose-helm-operator:v" + ocpProductVersion,
+			"registry.redhat.io/openshift4/ose-helm-rhel9-operator:v" + ocpProductVersion,
 		},
 		// Go
 		{

--- a/internal/plugins/openshift/v1/init_test.go
+++ b/internal/plugins/openshift/v1/init_test.go
@@ -79,9 +79,9 @@ FROM registry.redhat.io/openshift4/ose-ansible-operator:v` + ocpProductVersion +
 FROM quay.io/operator-framework/ansible:latest
 FROM foo/ansible-operator:latest
 
-FROM registry.redhat.io/openshift4/ose-helm-operator:v` + ocpProductVersion + `
-FROM registry.redhat.io/openshift4/ose-helm-operator:v` + ocpProductVersion + `
-FROM registry.redhat.io/openshift4/ose-helm-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-helm-rhel9-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-helm-rhel9-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-helm-rhel9-operator:v` + ocpProductVersion + `
 FROM quay.io/operator-framework/helm:latest
 FROM foo/helm-operator:latest
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Update base image of scaffolded Dockerfile for helm-operator to use rhel9 repository

**Motivation for the change:**
The helm-operator image is using rhel9 base image from 4.16 onwards and discontinued publishing rhel8 based image. The repository also has changed from `registry.redhat.io/openshift4/ose-helm-operator` to `registry.redhat.io/openshift4/ose-helm-rhel9-operator`. This PR fixes the scaffolded Dockerfile for helm-operator to use the correct image.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
