### PR TITLE
OCPBUGS-42729: Update base image of scaffolded Dockerfile for ansible-operator to use rhel9 repository

### DIFF
--- a/internal/plugins/openshift/v1/init.go
+++ b/internal/plugins/openshift/v1/init.go
@@ -72,7 +72,7 @@ var imageSubstitutions = map[string][]substitution{
 		// Ansible
 		{
 			regexp.MustCompile(`quay.io/operator-framework/ansible-operator:[^ \n]+`),
-			"registry.redhat.io/openshift4/ose-ansible-operator:v" + ocpProductVersion,
+			"registry.redhat.io/openshift4/ose-ansible-rhel9-operator:v" + ocpProductVersion,
 		},
 		// Helm
 		{

--- a/internal/plugins/openshift/v1/init_test.go
+++ b/internal/plugins/openshift/v1/init_test.go
@@ -73,9 +73,9 @@ FROM registry.access.redhat.com/ubi8/ubi-micro:8.1
 
 const dockerfileAllExp = `FROM foo:bar
 
-FROM registry.redhat.io/openshift4/ose-ansible-operator:v` + ocpProductVersion + `
-FROM registry.redhat.io/openshift4/ose-ansible-operator:v` + ocpProductVersion + `
-FROM registry.redhat.io/openshift4/ose-ansible-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-ansible-rhel9-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-ansible-rhel9-operator:v` + ocpProductVersion + `
+FROM registry.redhat.io/openshift4/ose-ansible-rhel9-operator:v` + ocpProductVersion + `
 FROM quay.io/operator-framework/ansible:latest
 FROM foo/ansible-operator:latest
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Update base image of scaffolded Dockerfile for ansible-operator to use rhel9 repository

**Motivation for the change:**
The ansible-operator image is using rhel9 base image from 4.17 onwards and discontinued publishing rhel8 based image. The repository also has changed from `registry.redhat.io/openshift4/ose-ansible-operator` to `registry.redhat.io/openshift4/ose-ansible-rhel9-operator`. This PR fixes the scaffolded Dockerfile for ansible-operator to use the correct image.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
