### PR TITLE
OCPBUGS-42948: Update base image of scaffolded Dockerfile for ose-kube-rbac-proxy to…

### DIFF
--- a/internal/plugins/openshift/v1/init.go
+++ b/internal/plugins/openshift/v1/init.go
@@ -65,7 +65,7 @@ var imageSubstitutions = map[string][]substitution{
 	filepath.Join("config", "default", "manager_auth_proxy_patch.yaml"): {
 		{
 			regexp.MustCompile(`gcr.io/kubebuilder/kube-rbac-proxy:[^ \n]+`),
-			"registry.redhat.io/openshift4/ose-kube-rbac-proxy:v" + ocpProductVersion,
+			"registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v" + ocpProductVersion,
 		},
 	},
 	filepath.Join("Dockerfile"): {

--- a/internal/plugins/openshift/v1/init_test.go
+++ b/internal/plugins/openshift/v1/init_test.go
@@ -119,9 +119,9 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v` + ocpProductVersion + `
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v` + ocpProductVersion + `
       - name: kube-rbac-proxy-latest
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v` + ocpProductVersion + `
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v` + ocpProductVersion + `
       - name: upstream
         image: quay.io/brancz/kube-rbac-proxy:v0.5.0
 `


### PR DESCRIPTION
**Description of the change:**
Update base image of scaffolded Dockerfile for ose-kube-rbac-proxy to use rhel9 repository


**Motivation for the change:**
The ose-kube-rbac-proxy image is using rhel9 base image from 4.16 onwards and discontinued publishing rhel8 based image. The repository also has changed from registry.redhat.io/openshift4/ose-kube-rbac-proxy to registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9. This PR fixes the scaffolded Dockerfile for ose-kube-rbac-proxy to use the correct image.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
