### PR TITLE
[release-4.16] Update the hybird helm dockerfileTemplate to 1.21

### DIFF
--- a/vendor/github.com/operator-framework/helm-operator-plugins/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
+++ b/vendor/github.com/operator-framework/helm-operator-plugins/pkg/plugins/hybrid/v1alpha/scaffolds/internal/templates/dockerfile.go
@@ -41,7 +41,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 // `api/` and `controller/` they would have to be added.
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
```
operator-sdk version: "v1.36.1-ocp", commit: "be22b34835cf7fbe985506936e9348233681ca3f", kubernetes version: "v1.29.0", go version: "go1.22.0", GOOS: "darwin", GOARCH: "arm64"

jitli@RedHat:~$ operator-sdk init --plugins=hybrid.helm.sdk.operatorframework.io --domain=hybird.com --project-version=3 --repo=github.com/example/memcached-operator

jitli@RedHat:~$ cat Dockerfile 
# Build the manager binary
FROM golang:1.20 as builder

WORKDIR /workspace
# Copy the Go Modules manifests
COPY go.mod go.mod
COPY go.sum go.sum


```