### PR TITLE
OCPBUGS-49323: Fix the release-4.18 ocpProductVersion

### DIFF
--- a/internal/plugins/openshift/v1/init.go
+++ b/internal/plugins/openshift/v1/init.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The current OCP release version.
-	ocpProductVersion = "4.19"
+	ocpProductVersion = "4.18"
 	// The currently used version of ubi9/ubi-minimal images.
 	ubiMinimalVersion = "9.4"
 )


### PR DESCRIPTION
Fix the release-4.18 ocpProductVersion
https://github.com/openshift/ocp-release-operator-sdk/pull/416/files#diff-fa5eae590fbd9f54ed4b66cdd4cc0c580ba0f62b7152b3c942c821ae42abc329 

<pre>
fail [/jenkins/workspace/ocp-common/ginkgo-test-vm/private/test/extended/operatorsdk/operatorsdk.go:4847]: Expected
    <string>: # Build the manager binary
    FROM registry.redhat.io/openshift4/ose-helm-rhel9-operator:v4.19
    
    ENV HOME=/opt/helm
    COPY watches.yaml ${HOME}/watches.yaml
    COPY helm-charts  ${HOME}/helm-charts
    WORKDIR ${HOME}
    
to contain substring
    <string>: registry.redhat.io/openshift4/ose-helm-rhel9-operator:v4.18

</pre>