### PR TITLE
Add symbolic link file checks for CVE-2025-53547

### DIFF
--- a/internal/plugins/helm/v1/chartutil/chart_test.go
+++ b/internal/plugins/helm/v1/chartutil/chart_test.go
@@ -209,3 +209,205 @@ func runTestCase(t *testing.T, testDir string, tc createChartTestCase) {
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(chartutil.HelmChartsDir, tc.expectChartName), chartPath)
 }
+
+// TestCVE2025_53547_Protection tests that ScaffoldChart properly detects and blocks symlinked Chart.lock files
+// This test validates the CVE-2025-53547 mitigation implemented in the validateForSymlink function.
+//
+// CVE-2025-53547 Details:
+// - High severity code injection vulnerability in Helm's dependency management
+// - Attack vector: malicious Chart.yaml content + symlinked Chart.lock file
+// - When dependencies are updated, malicious content gets written to symlinked target (e.g., ~/.bashrc)
+// - Results in arbitrary code execution when the target file is executed
+//
+// Protection Mechanism:
+// - validateForSymlink() checks if Chart.lock is a symlink before calling downloader.Manager.Build()
+// - Uses os.Lstat() to detect symlinks without following them
+// - Returns error with "CVE-2025-53547" message if symlink detected
+// - Called from fetchChartDependencies() during ScaffoldChart operations
+//
+// Test Coverage:
+// 1. Safe charts (no Chart.lock, regular Chart.lock) - should succeed
+// 2. Malicious charts (symlinked Chart.lock) - should fail with CVE error
+// 3. Multiple symlink scenarios (executable files, relative/absolute paths)
+//
+// Note: Some malicious charts may fail at chart loading stage due to Helm's
+// own symlink detection, which is additional protection beyond our fix.
+func TestCVE2025_53547_Protection(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupChart    func(string) error
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "safe chart with no Chart.lock",
+			setupChart: func(chartDir string) error {
+				// Create a basic Chart.yaml
+				chartYaml := `apiVersion: v2
+name: safe-chart
+description: A safe test chart
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+  - name: redis
+    version: "1.0.0"
+    repository: "https://charts.helm.sh/stable"
+`
+				return os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(chartYaml), 0644)
+			},
+			expectError: false,
+		},
+		{
+			name: "CVE-2025-53547: symlink detection (minimal test)",
+			setupChart: func(chartDir string) error {
+				// Create a minimal Chart.yaml that will definitely trigger dependency fetching
+				chartYaml := `apiVersion: v2
+name: symlink-test
+description: Minimal test for symlink detection
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+  - name: test-dep
+    version: "1.0.0"
+    repository: "https://example.com/charts"
+`
+				if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(chartYaml), 0644); err != nil {
+					return err
+				}
+
+				// Create a simple target file for the symlink
+				targetContent := "malicious content here"
+				targetFile := filepath.Join(chartDir, "target.txt")
+				if err := os.WriteFile(targetFile, []byte(targetContent), 0644); err != nil {
+					return err
+				}
+
+				// Create the symlink Chart.lock -> target.txt
+				return os.Symlink("target.txt", filepath.Join(chartDir, "Chart.lock"))
+			},
+			expectError:   true,
+			errorContains: "CVE-2025-53547",
+		},
+		{
+			name: "safe chart with regular Chart.lock",
+			setupChart: func(chartDir string) error {
+				// Create Chart.yaml
+				chartYaml := `apiVersion: v2
+name: safe-chart
+description: A safe test chart
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+  - name: redis
+    version: "1.0.0"
+    repository: "https://charts.helm.sh/stable"
+`
+				if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(chartYaml), 0644); err != nil {
+					return err
+				}
+				// Create a regular Chart.lock file
+				chartLock := `dependencies:
+- name: redis
+  repository: https://charts.helm.sh/stable
+  version: 1.0.0
+digest: sha256:1234567890abcdef
+generated: "2024-01-01T00:00:00Z"
+`
+				return os.WriteFile(filepath.Join(chartDir, "Chart.lock"), []byte(chartLock), 0644)
+			},
+			expectError: false,
+		},
+		{
+			name: "CVE-2025-53547: malicious chart with symlinked Chart.lock",
+			setupChart: func(chartDir string) error {
+				// Create Chart.yaml with dependencies
+				chartYaml := `apiVersion: v2
+name: malicious-chart
+description: A chart with symlinked Chart.lock (CVE-2025-53547 test)
+version: 1.0.0
+appVersion: 1.0.0
+dependencies:
+  - name: redis
+    version: "1.0.0"
+    repository: "https://charts.helm.sh/stable"
+`
+				if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(chartYaml), 0644); err != nil {
+					return err
+				}
+
+				// Create a target file that Chart.lock will be symlinked to
+				targetFile := filepath.Join(chartDir, "malicious_target.sh")
+				targetContent := "#!/bin/bash\necho 'This would be malicious code execution!'\n"
+				if err := os.WriteFile(targetFile, []byte(targetContent), 0755); err != nil {
+					return err
+				}
+
+				// Create the symlink Chart.lock -> malicious_target.sh (this is the attack vector)
+				return os.Symlink("malicious_target.sh", filepath.Join(chartDir, "Chart.lock"))
+			},
+			expectError:   true,
+			errorContains: "CVE-2025-53547",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directories for test
+			tmpProjectDir, err := os.MkdirTemp("", "test-project-cve")
+			assert.NoError(t, err)
+			defer os.RemoveAll(tmpProjectDir)
+
+			tmpChartDir, err := os.MkdirTemp("", "test-chart-cve")
+			assert.NoError(t, err)
+			defer os.RemoveAll(tmpChartDir)
+
+			// Setup test chart scenario
+			err = tt.setupChart(tmpChartDir)
+			assert.NoError(t, err)
+
+			// Load the chart from our test directory
+			chrt, err := chartutil.LoadChart(chartutil.Options{Chart: tmpChartDir})
+			if err != nil && tt.expectError {
+				// If we can't even load the chart and we expect an error, that's fine
+				// The error might be from chart loading rather than our symlink check
+				t.Logf("Chart loading failed as expected for malicious chart: %v", err)
+				return
+			}
+			if err != nil && !tt.expectError {
+				t.Errorf("Unexpected chart loading error for safe chart: %v", err)
+				return
+			}
+
+			// Only proceed with ScaffoldChart if chart loaded successfully
+			if chrt == nil {
+				t.Errorf("Chart is nil after successful loading")
+				return
+			}
+
+			// Test ScaffoldChart (this will trigger fetchChartDependencies and our CVE protection)
+			_, _, err = chartutil.ScaffoldChart(chrt, tmpProjectDir)
+
+			if tt.expectError {
+				assert.Error(t, err, "Expected an error but ScaffoldChart succeeded")
+				if err != nil && tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains,
+						"Expected error to contain '%s', but got: %v", tt.errorContains, err)
+				}
+				if err != nil {
+					t.Logf("Successfully blocked malicious symlink during ScaffoldChart: %v", err)
+				}
+			} else {
+				// Note: This might still fail due to missing dependencies in test environment,
+				// but it should NOT fail due to symlink detection
+				if err != nil && strings.Contains(err.Error(), "CVE-2025-53547") {
+					t.Errorf("Safe chart was incorrectly flagged as malicious: %v", err)
+				} else if err != nil {
+					// Expected failure due to missing dependencies, not a symlink issue
+					t.Logf("Note: Safe chart test had expected dependency error: %v", err)
+				} else {
+					t.Logf("Safe chart processed successfully")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION

**Description of the change:**

Based on the analysis from https://github.com/advisories/GHSA-557j-xg8c-q2mm, the vulnerability in operator-sdk is found in the code path leveraging the `downloader.Manager.Build()` method from Helm SDK. The fix for the CVE is adopted in the recent Helm SDK version 3.18.4. The same helm version is not adopted in the present release-4.18, hence, the PR adds update in the operator-sdk layer to mitigate the vulnerability.